### PR TITLE
Extend login session validity to one year

### DIFF
--- a/todoqueue_backend/todoqueue_backend/settings.py
+++ b/todoqueue_backend/todoqueue_backend/settings.py
@@ -227,8 +227,11 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
+# Keep the 30-day access token so clients regularly refresh and rotate tokens
+# each month, but extend the refresh token lifetime so a user can remain
+# logged in for up to a year without re-authenticating.
     "ACCESS_TOKEN_LIFETIME": timedelta(days=30),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=90),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=365),
     "ROTATE_REFRESH_TOKENS": True,
     "BLACKLIST_AFTER_ROTATION": True,
 }

--- a/todoqueue_frontend/src/api/axiosConfig.js
+++ b/todoqueue_frontend/src/api/axiosConfig.js
@@ -59,6 +59,7 @@ axios.interceptors.response.use(
         localStorage.setItem('access_token', response.data.access);
         localStorage.setItem('refresh_token', response.data.refresh);
 
+        refresh = false;
         return axios(error.config);
       } else {
         console.log("Failed to refresh token. Logging out.");


### PR DESCRIPTION
## Summary
- let refresh tokens remain valid for a year instead of 90 days
- reset refresh flag after successful token refresh

## Testing
- `pytest todoqueue_backend`
- `npm test --prefix todoqueue_frontend --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68533c0b2f088320a616aa847f3f3826